### PR TITLE
Trigger errors on API failures

### DIFF
--- a/lib/copperegg/client.rb
+++ b/lib/copperegg/client.rb
@@ -46,10 +46,11 @@ module Copperegg
     private
 
     def _send(method, path, body = {})
+      auth = @auth
       unless body.empty?
-        @auth.merge!({:headers => JSON}.merge!({:body => body.to_json}))
+        auth.merge!({:headers => JSON}.merge!({:body => body.to_json}))
       end
-      response = HTTParty.send(method.to_sym, @api_base_uri + path, @auth.to_hash)
+      response = HTTParty.send(method.to_sym, @api_base_uri + path, auth.to_hash)
       if response.code != 200
         raise("HTTP/#{method} Request failed. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
       end

--- a/lib/copperegg/client.rb
+++ b/lib/copperegg/client.rb
@@ -17,14 +17,6 @@ module Copperegg
       return self
     end
 
-    def get(resource, *args)
-      response = HTTParty.get(@api_base_uri + resource, @auth.to_hash)
-      if response.code != 200
-        raise("HTTP/Get request failed. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
-      end
-      response
-    end
-
     JSON = {'content-type' => 'application/json'}
 
     def method_missing(method, resource, *args)
@@ -35,24 +27,19 @@ module Copperegg
       end
     end
 
-    ['post', 'put'].each do |method|
+    ['get', 'post', 'put', 'delete'].each do |method|
       define_method(method) do |resource, *args|
-        body = {}
-        args.each { |arg| body.deep_merge!(arg) }
-        response = HTTParty.send(method.to_sym, @api_base_uri + resource, @auth.merge({:headers => JSON}.merge({:body => body.to_json})))
+        unless args.nil?
+          body = {}
+          args.each { |arg| body.deep_merge!(arg) }
+          @auth.merge!({:headers => JSON}.merge!({:body => body.to_json}))
+        end
+        response = HTTParty.send(method.to_sym, @api_base_uri + resource, @auth.to_hash)
         if response.code != 200
           raise("HTTP/#{method} Request failed. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
         end
         response
       end
-    end
-
-    def delete(resource, *args)
-      response = HTTParty.delete(@api_base_uri + resource, @auth.to_hash)
-      if response.code != 200
-        raise("HTTP/Delete request failed. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
-      end
-      response
     end
 
   end

--- a/lib/copperegg/client.rb
+++ b/lib/copperegg/client.rb
@@ -46,7 +46,7 @@ module Copperegg
     private
 
     def _send(method, path, body = {})
-      auth = @auth
+      auth = @auth.clone
       unless body.empty?
         auth.merge!({:headers => JSON}.merge!({:body => body.to_json}))
       end

--- a/lib/copperegg/client.rb
+++ b/lib/copperegg/client.rb
@@ -27,19 +27,33 @@ module Copperegg
       end
     end
 
-    ['get', 'post', 'put', 'delete'].each do |method|
-      define_method(method) do |resource, *args|
-        unless args.nil?
-          body = {}
-          args.each { |arg| body.deep_merge!(arg) }
-          @auth.merge!({:headers => JSON}.merge!({:body => body.to_json}))
-        end
-        response = HTTParty.send(method.to_sym, @api_base_uri + resource, @auth.to_hash)
-        if response.code != 200
-          raise("HTTP/#{method} Request failed. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
-        end
-        response
+    def get(path)
+      _send(:get, path)
+    end
+
+    def post(path, body)
+      _send(:post, path, body)
+    end
+
+    def put(path, body)
+      _send(:put, path, body)
+    end
+
+    def delete(path)
+      _send(:delete, path)
+    end
+
+    private
+
+    def _send(method, path, body = {})
+      unless body.empty?
+        @auth.merge!({:headers => JSON}.merge!({:body => body.to_json}))
       end
+      response = HTTParty.send(method.to_sym, @api_base_uri + path, @auth.to_hash)
+      if response.code != 200
+        raise("HTTP/#{method} Request failed. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
+      end
+      response
     end
 
   end

--- a/lib/copperegg/client.rb
+++ b/lib/copperegg/client.rb
@@ -18,7 +18,11 @@ module Copperegg
     end
 
     def get(resource, *args)
-      HTTParty.get(@api_base_uri + resource, @auth.to_hash)
+      response = HTTParty.get(@api_base_uri + resource, @auth.to_hash)
+      if response.code != 200
+        raise("HTTP/Get request failed. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
+      end
+      response
     end
 
     JSON = {'content-type' => 'application/json'}
@@ -35,12 +39,20 @@ module Copperegg
       define_method(method) do |resource, *args|
         body = {}
         args.each { |arg| body.deep_merge!(arg) }
-        HTTParty.send(method.to_sym, @api_base_uri + resource, @auth.merge({:headers => JSON}.merge({:body => body.to_json})))
+        response = HTTParty.send(method.to_sym, @api_base_uri + resource, @auth.merge({:headers => JSON}.merge({:body => body.to_json})))
+        if response.code != 200
+          raise("HTTP/#{method} Request failed. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
+        end
+        response
       end
     end
 
     def delete(resource, *args)
-      HTTParty.delete(@api_base_uri + resource, @auth.to_hash)
+      response = HTTParty.delete(@api_base_uri + resource, @auth.to_hash)
+      if response.code != 200
+        raise("HTTP/Delete request failed. Response code `#{response.code}`, message `#{response.message}`, body `#{response.body}`")
+      end
+      response
     end
 
   end

--- a/lib/copperegg/version.rb
+++ b/lib/copperegg/version.rb
@@ -1,3 +1,3 @@
 module Copperegg
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
 end

--- a/spec/alert_spec.rb
+++ b/spec/alert_spec.rb
@@ -53,7 +53,7 @@ describe Copperegg::Alerts do
     it 'deletes schedules from the instance list variable only if api call was successful' do
       alerts_schedules_list_size_before = @alerts.schedules.size
       VCR.use_cassette('schedule_reset_with_error', :record => :once, :match_requests_on => [:method, :path]) do
-        expect { @alerts.delete_schedules('spec_test') }.to raise_error(RuntimeError)
+        expect { @alerts.delete_schedules('spec_test') }.to raise_error(RuntimeError, /HTTP.*failed/)
       end
       expect(alerts_schedules_list_size_before - @alerts.schedules.size).to eq(3)
       expect(WebMock).to have_requested(:delete, /.*alerts\/schedules\/\d+\.json$/).times(3)

--- a/spec/alert_spec.rb
+++ b/spec/alert_spec.rb
@@ -53,9 +53,9 @@ describe Copperegg::Alerts do
     it 'deletes schedules from the instance list variable only if api call was successful' do
       alerts_schedules_list_size_before = @alerts.schedules.size
       VCR.use_cassette('schedule_reset_with_error', :record => :once, :match_requests_on => [:method, :path]) do
-        @alerts.delete_schedules('spec_test')
+        expect { @alerts.delete_schedules('spec_test') }.to raise_error(RuntimeError)
       end
-      expect(alerts_schedules_list_size_before - @alerts.schedules.size).to eq(2)
+      expect(alerts_schedules_list_size_before - @alerts.schedules.size).to eq(3)
       expect(WebMock).to have_requested(:delete, /.*alerts\/schedules\/\d+\.json$/).times(3)
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -22,7 +22,7 @@ describe Copperegg::Client do
     end
 
     %w(get delete).each do |verb|
-      it "returns nil on wrong #{verb}" do
+      it "fails on wrong #{verb}" do
         VCR.use_cassette('4xx', :record => :once, :match_requests_on => [:path], :allow_playback_repeats => true) do
           expect { @client.send(verb + '?', 'veryWrong') }.to raise_error(RuntimeError, /HTTP.*failed/)
         end
@@ -30,7 +30,7 @@ describe Copperegg::Client do
     end
 
     %w(post put).each do |verb|
-      it "returns nil on wrong #{verb}" do
+      it "fails on wrong #{verb}" do
         VCR.use_cassette('4xx', :record => :once, :match_requests_on => [:path], :allow_playback_repeats => true) do
           expect { @client.send(verb + '?', 'veryWrong', {}) }.to raise_error(RuntimeError, /HTTP.*failed/)
         end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -21,10 +21,18 @@ describe Copperegg::Client do
       expect(@auth) == {:basic_auth => {:username => Copperegg::Test::API_KEY, :password => 'U'}}
     end
 
-    %w(get post put delete).each do |verb|
+    %w(get delete).each do |verb|
       it "returns nil on wrong #{verb}" do
         VCR.use_cassette('4xx', :record => :once, :match_requests_on => [:path], :allow_playback_repeats => true) do
-          expect(@client.send(verb + '?', 'veryWrong', {} )).to eq(nil)
+          expect { @client.send(verb + '?', 'veryWrong') }.to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    %w(post put).each do |verb|
+      it "returns nil on wrong #{verb}" do
+        VCR.use_cassette('4xx', :record => :once, :match_requests_on => [:path], :allow_playback_repeats => true) do
+          expect { @client.send(verb + '?', 'veryWrong', {}) }.to raise_error(RuntimeError)
         end
       end
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -24,7 +24,7 @@ describe Copperegg::Client do
     %w(get delete).each do |verb|
       it "returns nil on wrong #{verb}" do
         VCR.use_cassette('4xx', :record => :once, :match_requests_on => [:path], :allow_playback_repeats => true) do
-          expect { @client.send(verb + '?', 'veryWrong') }.to raise_error(RuntimeError)
+          expect { @client.send(verb + '?', 'veryWrong') }.to raise_error(RuntimeError, /HTTP.*failed/)
         end
       end
     end
@@ -32,7 +32,7 @@ describe Copperegg::Client do
     %w(post put).each do |verb|
       it "returns nil on wrong #{verb}" do
         VCR.use_cassette('4xx', :record => :once, :match_requests_on => [:path], :allow_playback_repeats => true) do
-          expect { @client.send(verb + '?', 'veryWrong', {}) }.to raise_error(RuntimeError)
+          expect { @client.send(verb + '?', 'veryWrong', {}) }.to raise_error(RuntimeError, /HTTP.*failed/)
         end
       end
     end


### PR DESCRIPTION
If for some reason the initial get in https://github.com/cargomedia/copperegg-alerts/blob/master/lib/copperegg/alerts.rb#L9 fails, we should make sure that either
* other methods don't use `@schedules` unchecked
* raise an error
* raise an error after having retried n times (n>0)  to get an answer

@njam @tomaszdurka @kris-lab what's your favorite?
